### PR TITLE
In-place verification and stack trace information

### DIFF
--- a/Tests/AssertGroupTests.cs
+++ b/Tests/AssertGroupTests.cs
@@ -5,6 +5,7 @@ namespace Tests
     using NUnit.Framework;
 
     using Nunit_GroupAssert;
+    using System;
 
     #endregion
 
@@ -25,11 +26,35 @@ namespace Tests
         }
 
         [Test]
-        public void Vertify_DoesNotThrow_WhenNoException()
+        public void Verify_DoesNotThrow_WhenNoException()
         {
             var group = new AssertGroup();
             group.Add(() => Assert.AreEqual(1, 1));
             group.Add(() => Assert.AreEqual(2, 2));
+            group.Verify();
+        }
+
+        internal class Obj
+        {
+            public int Value { get; set; }
+
+            public Obj(int Value)
+            {
+                this.Value = Value;
+            }
+        }
+
+
+        [Test]
+        public void Verify_ThatThow_InPlace()
+        {
+            Obj v = new Obj(10);
+
+            var group = new AssertGroup();
+            group.Add(() => Assert.AreEqual(v.Value, 11)); // should fail test
+
+            v.Value = 10;
+
             group.Verify();
         }
     }

--- a/Tests/AssertGroupTests.cs
+++ b/Tests/AssertGroupTests.cs
@@ -5,7 +5,6 @@ namespace Tests
     using NUnit.Framework;
 
     using Nunit_GroupAssert;
-    using System;
 
     #endregion
 
@@ -44,14 +43,13 @@ namespace Tests
             }
         }
 
-
         [Test]
         public void Verify_ThatThow_InPlace()
         {
             Obj v = new Obj(10);
 
             var group = new AssertGroup();
-            group.Add(() => Assert.AreEqual(v.Value, 11)); // should fail test
+            group.Add(() => Assert.AreEqual(v.Value, 11, "Should fail test"));
 
             v.Value = 10;
 

--- a/Tests/AssertGroupTests.cs
+++ b/Tests/AssertGroupTests.cs
@@ -44,7 +44,7 @@ namespace Tests
         }
 
         [Test]
-        public void Verify_ThatThow_InPlace()
+        public void Verify_ThatThrow_InPlace()
         {
             Obj v = new Obj(10);
 

--- a/src/AssertGroup.cs
+++ b/src/AssertGroup.cs
@@ -8,6 +8,7 @@ namespace Nunit_GroupAssert
     using System.Text;
 
     using NUnit.Framework;
+    using System.Diagnostics;
 
     #endregion
 
@@ -32,9 +33,7 @@ namespace Nunit_GroupAssert
 
         public bool ShowFailingFilePath { get; set; }
 
-        public void Add(
-            Action assertion, [CallerLineNumber] int lineNumber = 0, [CallerMemberName] string caller = null,
-            [CallerFilePath] string filePath = null)
+        public void Add(Action assertion)
         {
             try
             {
@@ -43,7 +42,7 @@ namespace Nunit_GroupAssert
             catch (AssertionException exception)
             {
                 this._assertions.Add(new GroupedAssertion(exception.Message,
-                    new System.Diagnostics.StackTrace(exception, true)));
+                    new StackTrace(exception, true)));
             }
         }
 

--- a/src/GroupedAssertion.cs
+++ b/src/GroupedAssertion.cs
@@ -3,30 +3,20 @@ namespace Nunit_GroupAssert
     #region
 
     using System;
+    using System.Diagnostics;
 
     #endregion
 
     public class GroupedAssertion
     {
-        private readonly Action _action;
+        public String Message { get; private set; }
 
-        public GroupedAssertion(Action action, int lineNumber, string caller, string filePath)
+        public StackTrace StackTrace { get; private set; }
+
+        public GroupedAssertion(String message, StackTrace stackTrace)
         {
-            this._action = action;
-            this.LineNumber = lineNumber;
-            this.FilePath = filePath;
-            this.Caller = caller;
-        }
-
-        public string Caller { get; private set; }
-
-        public int LineNumber { get; private set; }
-
-        public string FilePath { get; private set; }
-
-        public void Execute()
-        {
-            this._action();
+            this.Message = message;
+            this.StackTrace = stackTrace;
         }
     }
 }


### PR DESCRIPTION
Now GroupAssert makes execution at the `Add()` call.
Also stack trace information. Looks like:

```
Test 'Tests.AssertGroupTests.Verify_GroupsExceptions' failed: Test failed because one or more assertions failed: 
1)  Expected: 10
      But was:  20
   at NUnit.Framework.Assert.That(Object actual, IResolveConstraint expression, String message, Object[] args)
   at NUnit.Framework.Assert.AreEqual(Int32 expected, Int32 actual)
   at Tests.AssertGroupTests.<Verify_GroupsExceptions>b__0() in d:\Git\NUnit-GroupAssert\Tests\AssertGroupTests.cs:line 20
   at Nunit_GroupAssert.AssertGroup.Add(Action assertion) in d:\Git\NUnit-GroupAssert\src\AssertGroup.cs:line 40


2)  Expected: 3
      But was:  4
   at NUnit.Framework.Assert.That(Object actual, IResolveConstraint expression, String message, Object[] args)
   at NUnit.Framework.Assert.AreEqual(Int32 expected, Int32 actual)
   at Tests.AssertGroupTests.<Verify_GroupsExceptions>b__2() in d:\Git\NUnit-GroupAssert\Tests\AssertGroupTests.cs:line 22
   at Nunit_GroupAssert.AssertGroup.Add(Action assertion) in d:\Git\NUnit-GroupAssert\src\AssertGroup.cs:line 40


3)  Expected: True
      But was:  False
   at NUnit.Framework.Assert.That(Object actual, IResolveConstraint expression, String message, Object[] args)
   at NUnit.Framework.Assert.IsTrue(Boolean condition)
   at Tests.AssertGroupTests.<Verify_GroupsExceptions>b__3() in d:\Git\NUnit-GroupAssert\Tests\AssertGroupTests.cs:line 23
   at Nunit_GroupAssert.AssertGroup.Add(Action assertion) in d:\Git\NUnit-GroupAssert\src\AssertGroup.cs:line 40

    AssertGroup.cs(72,0): at Nunit_GroupAssert.AssertGroup.Verify()
    AssertGroup.cs(30,0): at Nunit_GroupAssert.AssertGroup.Dispose()
    AssertGroupTests.cs(24,0): at Tests.AssertGroupTests.Verify_GroupsExceptions()

Test 'Tests.AssertGroupTests.Verify_ThatThow_InPlace' failed: Test failed because one or more assertions failed: 
1)  Should fail test
      Expected: 10
      But was:  11
   at NUnit.Framework.Assert.That(Object actual, IResolveConstraint expression, String message, Object[] args)
   at NUnit.Framework.Assert.AreEqual(Int32 expected, Int32 actual, String message)
   at Tests.AssertGroupTests.<>c__DisplayClassd.<Verify_ThatThow_InPlace>b__c() in d:\Git\NUnit-GroupAssert\Tests\AssertGroupTests.cs:line 52
   at Nunit_GroupAssert.AssertGroup.Add(Action assertion) in d:\Git\NUnit-GroupAssert\src\AssertGroup.cs:line 40

    AssertGroup.cs(72,0): at Nunit_GroupAssert.AssertGroup.Verify()
    AssertGroupTests.cs(56,0): at Tests.AssertGroupTests.Verify_ThatThow_InPlace()

1 passed, 2 failed, 0 skipped, took 0.32 seconds (NUnit 2.6.2).
```
